### PR TITLE
Add Flickr group pool

### DIFF
--- a/2015-Slides.md
+++ b/2015-Slides.md
@@ -8,7 +8,9 @@ A collection of links to slide decks and source code from talks at [360|iDev](ht
 
 # Photos
 
-Flickr photoset: https://www.flickr.com/photos/abunur/sets/72157655001424693
+Official Flickr photoset: https://www.flickr.com/photos/abunur/sets/72157655001424693
+
+Flickr group pool (add your own photos here!): https://www.flickr.com/groups/2898833@N22/
 
 -----
 


### PR DESCRIPTION
Aside from the "official" photos, attendees and speakers can and should add their own photos to the group pool.